### PR TITLE
feat: GitHub Issues → Notion 自動同期

### DIFF
--- a/.github/scripts/sync-issue.js
+++ b/.github/scripts/sync-issue.js
@@ -1,0 +1,40 @@
+'use strict';
+const fs = require('fs');
+const TOKEN = process.env.NOTION_TOKEN;
+const DB_ID = process.env.NOTION_DATABASE_ID;
+const PHASE = {"phase-1":"Phase-1","phase-2":"Phase-2","phase-3":"Phase-3","setup":"Setup"};
+const PRIO  = {"P0-critical":"🔴 P0-Critical","P1-important":"🟠 P1-Important","P2-nice-to-have":"🟡 P2-Nice-to-have"};
+
+async function api(path, method="GET", body=null) {
+  const r = await fetch(`https://api.notion.com/v1${path}`, {
+    method, headers:{"Authorization":`Bearer ${TOKEN}`,"Content-Type":"application/json","Notion-Version":"2022-06-28"},
+    body: body ? JSON.stringify(body) : undefined
+  });
+  const d = await r.json();
+  if (!r.ok) throw new Error(JSON.stringify(d.message||d));
+  return d;
+}
+
+async function sync(issue) {
+  const labels = (issue.labels||[]).map(l=>l.name);
+  const props = {
+    "Name":         {title:[{text:{content:issue.title}}]},
+    "Issue_Number": {number:issue.number},
+    "Status":       {select:{name:issue.state==="open"?"🟢 Open":"⚫ Closed"}},
+    "GitHub_URL":   {url:issue.html_url},
+    "Labels":       {multi_select:labels.map(n=>({name:n}))},
+  };
+  const phase = labels.map(l=>PHASE[l]).find(Boolean);
+  const prio  = labels.map(l=>PRIO[l]).find(Boolean);
+  if (phase) props.Phase    = {select:{name:phase}};
+  if (prio)  props.Priority = {select:{name:prio}};
+  if (issue.milestone) props.Milestone = {select:{name:issue.milestone.title}};
+
+  const r = await api(`/databases/${DB_ID}/query`,"POST",{filter:{property:"Issue_Number",number:{equals:issue.number}}});
+  const id = r.results[0]?.id;
+  if (id) { await api(`/pages/${id}`,"PATCH",{properties:props}); console.log(`✅ 更新: #${issue.number}`); }
+  else    { await api("/pages","POST",{parent:{database_id:DB_ID},properties:props}); console.log(`✨ 作成: #${issue.number}`); }
+}
+
+const issue = JSON.parse(fs.readFileSync(process.argv[2],'utf8'));
+sync(issue).catch(e=>{console.error("❌",e.message);process.exit(1);});

--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -1,0 +1,18 @@
+name: 🔄 Sync Issues to Notion
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled, closed, reopened, milestoned]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Write issue JSON
+        run: echo '${{ toJson(github.event.issue) }}' > /tmp/issue.json
+      - name: Sync to Notion
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+        run: node .github/scripts/sync-issue.js /tmp/issue.json


### PR DESCRIPTION
## S-006 完了

- GitHub Issues → Notion データベース自動同期ワークフロー追加
- Issue 変更時に Notion が自動更新される
- 60件の初期同期済み

closes #6